### PR TITLE
Android namespace added

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace 'com.mgerbie.snapshot_guard'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Problem on Android solved

```
A problem occurred configuring project ':snapshot_guard'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: ...\AppData\Local\Pub\Cache\hosted\pub.dev\snapshot_guard-0.0.3\android\build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

@omaralmgerbie @omarmgerbie please review and merge it

For now it can be used by importing fork version in pubspec.yaml:
```
  snapshot_guard: 
    git:
      url: https://github.com/AlexSeednov/snapshot_guard
      ref: android_fix
```